### PR TITLE
Complain noisily if q2pro.menu is missing

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -77,6 +77,10 @@ Both should be patched to 3.20 point release.
 Run `sudo ninja -C builddir install` to install Q2PRO system-wide into
 configured prefix (`/usr/local` by default).
 
+**NOTE:** If not using `ninja install`, be sure to copy
+`src/client/ui/q2pro.menu` into your `baseq2/` folder.  This file is required
+to display in-game menus.
+
 Copy `baseq2/pak*.pak` files and `baseq2/players` directory from unpacked
 Quake 2 data into `/usr/local/share/q2pro/baseq2` to complete the
 installation.

--- a/src/client/ui/script.c
+++ b/src/client/ui/script.c
@@ -765,5 +765,8 @@ static bool Parse_File(const char *path, int depth)
 
 void UI_LoadScript(void)
 {
-    Parse_File("q2pro.menu", 0);
+	if (!Parse_File("q2pro.menu", 0)) {
+		Com_EPrintf("Could not load menu q2pro.menu!  Menus will NOT work.\n");
+		Com_EPrintf("See https://github.com/q2pro/q2pro/blob/master/BUILDING.md#installation\n");
+	}
 }


### PR DESCRIPTION
This change should reduce the number of inquires from new q2pro users when the menus don't appear after compilation.

Evidence of q2pro.menu as a recurring friction point:

- https://discord.com/channels/1067136584056578080/1067139111481262113/1074592191126720582
- https://discord.com/channels/1067136584056578080/1104157631364481126/1465071753960226846
- https://discord.com/channels/1067136584056578080/1067182689175740416/1464295935227068639

What the change looks like from console:

<img width="1288" height="498" alt="image" src="https://github.com/user-attachments/assets/50d7740c-a2da-4104-81f6-ebdf65c7eef5" />
